### PR TITLE
Emit a console.warn when doing any overrides on a tab. Fixes #47

### DIFF
--- a/src/lib/console_warning_helper.js
+++ b/src/lib/console_warning_helper.js
@@ -1,3 +1,11 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/* globals module */
+
 const ConsoleWarningEyeCatch = "Oh no!";
 const ConsoleWarningDetails = `
 This web site has a web compatibility issue.
@@ -18,3 +26,5 @@ function promiseConsoleWarningScript(domain) {
            }`,
   });
 }
+
+module.exports = promiseConsoleWarningScript;

--- a/src/lib/console_warning_helper.js
+++ b/src/lib/console_warning_helper.js
@@ -1,0 +1,20 @@
+const ConsoleWarningEyeCatch = "Oh no!";
+const ConsoleWarningDetails = `
+This web site has a web compatibility issue.
+If you see this message, you are probably a
+developer that works on $DOMAIN$
+As you can see from our about:compat page,
+our browser has to use some work-arounds on this site.
+Please fix these issues.`;
+
+function promiseConsoleWarningScript(domain) {
+  const details = ConsoleWarningDetails.replace("$DOMAIN$", domain);
+  return Promise.resolve({
+    code: `if (!window.alreadyWarned) {
+             window.alreadyWarned = true;
+             console.warn("%c${ConsoleWarningEyeCatch}",
+               "font-size:50px; font-weight:bold; color:red; -webkit-text-stroke:1px black",
+               ${JSON.stringify(details)});
+           }`,
+  });
+}

--- a/src/lib/injections.js
+++ b/src/lib/injections.js
@@ -4,7 +4,11 @@
 
 "use strict";
 
-/* globals browser, module */
+/* globals browser, module, promiseConsoleWarningScript */
+
+if (typeof promiseConsoleWarningScript === "undefined") {
+  global.promiseConsoleWarningScript = require("./console_warning_helper");
+}
 
 class Injections {
   constructor(availableInjections) {

--- a/src/lib/ua_overrides.js
+++ b/src/lib/ua_overrides.js
@@ -59,6 +59,9 @@ class UAOverrides {
           header.value = uaTransformer(header.value);
         }
       }
+      promiseConsoleWarningScript(override.domain).then(script => {
+        browser.tabs.executeScript(details.tabId, script).catch(() => {});
+      });
       return { requestHeaders: details.requestHeaders };
     };
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -41,6 +41,7 @@
   "background": {
     "scripts": [
       "lib/module_shim.js",
+      "lib/console_warning_helper.js",
       "data/injections.js",
       "data/ua_overrides.js",
       "lib/about_compat_broker.js",

--- a/src/moz.build
+++ b/src/moz.build
@@ -42,6 +42,7 @@ FINAL_TARGET_FILES.features['webcompat@mozilla.org']['injections']['js'] += [
 
 FINAL_TARGET_FILES.features['webcompat@mozilla.org']['lib'] += [
   'lib/about_compat_broker.js',
+  'lib/console_warning_helper.js',
   'lib/injections.js',
   'lib/module_shim.js',
   'lib/ua_overrides.js'


### PR DESCRIPTION
Note that no attempt is made in this patch to do any l10n on the related messages, because there is no FTL interface on content scripts for system addons yet (and it can rely on strings which already aren't being localized, like the ones for the PDK fix, which is hard-coded to use the string "Sites using PDK 5" right now about:compat).

Unless I've missed a memo or two, we currently would have to do things how the [webcompat reporter is doing](https://searchfox.org/mozilla-central/source/browser/extensions/report-site-issue/experimentalAPIs/l10n.js) (which I think other addons are doing as well). But I'm not sure if that's what we want to do. We should check with the l10n team to make a decision here.