### PR TITLE
Bug 1649325. Adds cloudreadykb.neverware.com to salesforce issue

### DIFF
--- a/src/data/injections.js
+++ b/src/data/injections.js
@@ -132,6 +132,7 @@ const AVAILABLE_INJECTIONS = [
           "https://help.doordash.com/*",
           "https://community.snowflake.com/*",
           "https://tivoidp.tivo.com/*",
+          "https://cloudreadykb.neverware.com/*",
         ],
         InterventionHelpers.matchPatternsForTLDs(
           "*://support.ancestry.",


### PR DESCRIPTION
This will fix the issue with the donotshowunsupported message cloudreadykb.neverware.com.