### PR TITLE
Bug 1652025 - Remove Intervention for "files with no content-type"

### DIFF
--- a/src/data/injections.js
+++ b/src/data/injections.js
@@ -160,23 +160,6 @@ const AVAILABLE_INJECTIONS = [
     customFunc: "pdk5fix",
   },
   {
-    id: "bug1577870",
-    platform: "desktop",
-    domain: "Download prompt for files with no content-type",
-    bug: "1577870",
-    data: {
-      urls: [
-        "https://ads-us.rd.linksynergy.com/as.php*",
-        "https://www.office.com/logout?sid*",
-      ],
-      contentType: {
-        name: "content-type",
-        value: "text/html; charset=utf-8",
-      },
-    },
-    customFunc: "noSniffFix",
-  },
-  {
     id: "bug1561371",
     platform: "android",
     domain: "mail.google.com",


### PR DESCRIPTION
see https://bugzilla.mozilla.org/show_bug.cgi?id=1652025

I was not sure if I should keep or remove the code inside the injection-spec.js 