### PR TITLE
Hide picture-in-picture toggle on NetFlix /latest landings. Fixes #171

### DIFF
--- a/src/data/picture_in_picture_overrides.js
+++ b/src/data/picture_in_picture_overrides.js
@@ -32,6 +32,7 @@ let AVAILABLE_PIP_OVERRIDES;
 
     netflix: {
       "https://*.netflix.com/browse": TOGGLE_POLICIES.HIDDEN,
+      "https://*.netflix.com/latest": TOGGLE_POLICIES.HIDDEN,
     },
 
     twitch: {


### PR DESCRIPTION
(See https://bugzilla.mozilla.org/show_bug.cgi?id=1655665#c7 for context).