### PR TITLE
Collection of various "maintenance" patches.

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -174,14 +174,6 @@ task("export-mc", ["build"], () => {
   exportFiles(getMozillaCentralLocation(), "browser/extensions/webcompat");
 });
 
-desc("Exports the sources into the mozilla-central for android");
-task("export-mc-android", ["build"], () => {
-  exportFiles(
-    getMozillaCentralLocation(),
-    "mobile/android/extensions/webcompat"
-  );
-});
-
 desc("Exports the sources into the android-components repo");
 task("export-ac", ["build"], () => {
   deleteBuiltFiles(AC_IGNORE_PATHS);

--- a/Jakefile
+++ b/Jakefile
@@ -93,7 +93,7 @@ function getAndroidComponentsLocation() {
 }
 
 /**
- * Replaces file list placeholders in moz.build
+ * Replaces file list placeholders in moz.build and manifest.json
  *
  * returns {promise}
  */
@@ -110,34 +110,21 @@ function replaceFilelistPlaceholders(cssInjections, jsInjections, shims) {
     };
 
     let mozBuildFilename = path.join(BUILD_DIR, "moz.build");
-    try {
-      fs.statSync(mozBuildFilename).isFile();
-    } catch (ex) {
-      reject("Cannot generate the injection file list: no moz.build");
-    }
-
-    let manifestFilename = path.join(BUILD_DIR, "manifest.json");
-    try {
-      fs.statSync(manifestFilename).isFile();
-    } catch (ex) {
-      reject("Cannot generate the injection file list: no manifest.json");
-    }
-
     let mozBuildContents = fs.readFileSync(mozBuildFilename).toString();
     mozBuildContents = mozBuildContents
       .replace("@CSS_INJECTIONS@", formatList(cssInjections))
       .replace("@JS_INJECTIONS@", formatList(jsInjections))
       .replace("@SHIMS@", formatList(shims));
-
     fs.writeFileSync(mozBuildFilename, mozBuildContents);
 
+    let manifestFilename = path.join(BUILD_DIR, "manifest.json");
     let manifestContents = fs.readFileSync(manifestFilename).toString();
     manifestContents = manifestContents.replace(
       `["@WEB_ACCESSIBLE_RESOURCES@"]`,
       formatListForManifest(shims)
     );
-
     fs.writeFileSync(manifestFilename, manifestContents);
+
     resolve();
   });
 }

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If this is the first time you're working with this repository, install the depen
 
 1. Ensure the version number is bumped in `src/manifest.json`, appropriately (see [Versioning Scheme](https://github.com/mozilla/webcompat-addon/wiki/Versioning-Scheme) for more info).
 2. Make sure the `EXPORT_MC_LOCATION` environment variable is set to the root of your `mozilla-central` checkout.
-3. Run `npm run jake export-mc` for Desktop or `npm run jake export-mc-android` for Android.
+3. Run `npm run jake export-mc`.
 4. Find the exported files in your `mozilla-central` directory, ready to commit.
 
 ### Exporting the sources into Android Components

--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ Since the WebCompat feature inside Fenix is not shipped directly to the product 
 1. Run `npm run test`
 2. Wait!
 
+### Run tests inside `mozilla-central`
+
+Tests located in `src/tests/` are not automatically started by the CI in this repo, but are meant as in-tree tests that run together with other Firefox tests. These tests are triggered when trying to land things via Phabricator, but manually running them is also possible.
+
+1. Export the sources to `mozilla-central` as explained above.
+2. Switch into your `mozilla-central` directory.
+3. Build the changed sources into Firefox by running `./mach build`.
+4. Run the test suite with `./mach mochitest browser/extensions/webcompat/`.
+
 ### Automatically check and adjust the code style
 
 As `mozilla-central` is now mostly auto-formatted with prettier, and the config for that is really slim, this repo follows these guidelines. To automatically check and adjust the code style,

--- a/spec/available_injections.spec.js
+++ b/spec/available_injections.spec.js
@@ -7,6 +7,8 @@
 const fs = require("fs");
 const path = require("path");
 
+const WebExtManifestSchmea = require("./helpers/webext_manifest_schema");
+
 const AVAILABLE_INJECTIONS = require("../src/data/injections");
 
 describe("AVAILABLE_INJECTIONS", () => {
@@ -53,8 +55,12 @@ for (const injection of AVAILABLE_INJECTIONS) {
     });
 
     if (injection.contentScripts) {
-      it("provides a contentScript matches scope", () => {
-        expect(injection.contentScripts.matches).toBeTruthy();
+      it("provides valid URLs", () => {
+        expect(
+          WebExtManifestSchmea.matchPatternsValid(
+            injection.contentScripts.matches
+          )
+        ).toBeTruthy();
       });
 
       it("provides valid filenames for contentScripts", () => {

--- a/spec/available_ua_overrides.spec.js
+++ b/spec/available_ua_overrides.spec.js
@@ -4,6 +4,8 @@
 
 "use strict";
 
+const WebExtManifestSchmea = require("./helpers/webext_manifest_schema");
+
 const AVAILABLE_UA_OVERRIDES = require("../src/data/ua_overrides");
 const TEST_UA =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:69.0) Gecko/20100101 Firefox/69.0";
@@ -51,8 +53,10 @@ for (const override of AVAILABLE_UA_OVERRIDES) {
       expect(override.bug).toBeTruthy();
     });
 
-    it("provides an URL scope", () => {
-      expect(override.config.matches).toBeTruthy();
+    it("provides valid URLs", () => {
+      expect(
+        WebExtManifestSchmea.matchPatternsValid(override.config.matches)
+      ).toBeTruthy();
     });
 
     it("provides an uaTransformer that does return a string", () => {

--- a/spec/helpers/webext_manifest_schema.js
+++ b/spec/helpers/webext_manifest_schema.js
@@ -1,0 +1,18 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const WEBEXT_MATCH_PATTERN = new RegExp(
+  "^(https?|wss?|file|ftp|\\*)://(\\*|\\*\\.[^*/]+|[^*/]+)/.*$",
+  "i"
+);
+
+module.exports = {
+  matchPatternsValid: patterns => {
+    return patterns.every(
+      pattern => pattern.match(WEBEXT_MATCH_PATTERN) !== null
+    );
+  },
+};

--- a/src/injections/js/bug1452707-window.controllers-shim-ib.absa.co.za.js
+++ b/src/injections/js/bug1452707-window.controllers-shim-ib.absa.co.za.js
@@ -16,10 +16,6 @@
 
 /* globals exportFunction */
 
-console.info(
-  "window.controllers has been shimmed for compatibility reasons. See https://webcompat.com/issues/16401 for details."
-);
-
 Object.defineProperty(window.wrappedJSObject, "controllers", {
   get: exportFunction(function() {
     return true;

--- a/src/injections/js/bug1457335-histography.io-ua-change.js
+++ b/src/injections/js/bug1457335-histography.io-ua-change.js
@@ -11,10 +11,6 @@
 
 /* globals exportFunction */
 
-console.info(
-  "The user agent has been overridden for compatibility reasons. See https://webcompat.com/issues/1804 for details."
-);
-
 const CHROME_UA = navigator.userAgent + " Chrome for WebCompat";
 
 Object.defineProperty(window.navigator.wrappedJSObject, "userAgent", {

--- a/src/injections/js/bug1472075-bankofamerica.com-ua-change.js
+++ b/src/injections/js/bug1472075-bankofamerica.com-ua-change.js
@@ -13,10 +13,6 @@
 /* globals exportFunction */
 
 if (!navigator.platform.includes("Win")) {
-  console.info(
-    "The user agent has been overridden for compatibility reasons. See https://webcompat.com/issues/2787 for details."
-  );
-
   const WINDOWS_UA = navigator.userAgent.replace(
     /\(.*; rv:/i,
     "(Windows NT 10.0; Win64; x64; rv:"

--- a/src/injections/js/bug1570856-medium.com-menu-isTier1.js
+++ b/src/injections/js/bug1570856-medium.com-menu-isTier1.js
@@ -11,10 +11,6 @@
 
 /* globals exportFunction */
 
-console.info(
-  "window.GLOBALS.useragent.isTier1 has been set to true for compatibility reasons. See https://webcompat.com/issues/25844 for details."
-);
-
 let globals = {};
 
 Object.defineProperty(window.wrappedJSObject, "GLOBALS", {

--- a/src/injections/js/bug1579159-m.tailieu.vn-pdfjs-worker-disable.js
+++ b/src/injections/js/bug1579159-m.tailieu.vn-pdfjs-worker-disable.js
@@ -10,10 +10,6 @@
 
 /* globals exportFunction */
 
-console.info(
-  "window.PDFJS.disableWorker has been set to true for compatibility reasons. See https://webcompat.com/issues/39057 for details."
-);
-
 let globals = {};
 
 Object.defineProperty(window.wrappedJSObject, "PDFJS", {

--- a/src/injections/js/bug1610358-pcloud.com-appVersion-change.js
+++ b/src/injections/js/bug1610358-pcloud.com-appVersion-change.js
@@ -10,10 +10,6 @@
 
 /* globals exportFunction */
 
-console.info(
-  "The user agent has been overridden for compatibility reasons. See https://webcompat.com/issues/40353 for details."
-);
-
 const APP_VERSION = navigator.appVersion + " mobile";
 
 Object.defineProperty(window.navigator.wrappedJSObject, "appVersion", {

--- a/src/injections/js/bug1654906-contentDocument-fix.js
+++ b/src/injections/js/bug1654906-contentDocument-fix.js
@@ -13,10 +13,6 @@
 
 /* globals exportFunction */
 
-console.info(
-  "iframe.contentDocument has been shimmed for compatibility reasons. See https://webcompat.com/issues/55001 for details."
-);
-
 var elemProto = window.wrappedJSObject.Element.prototype;
 var innerHTML = Object.getOwnPropertyDescriptor(elemProto, "innerHTML");
 var iFrameProto = window.wrappedJSObject.HTMLIFrameElement.prototype;

--- a/src/lib/console_warning_helper.js
+++ b/src/lib/console_warning_helper.js
@@ -1,0 +1,24 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/* globals module */
+
+const ConsoleWarningEyeCatch = "Oh no!";
+const ConsoleWarningDetails = `This web site has a web compatibility issue in Firefox. If you see this message and are responsible for working on $DOMAIN$, please investigate. More details about this issue and how to disable our workaround can be found on our about:compat page.`;
+
+function promiseConsoleWarningScript(domain) {
+  const details = ConsoleWarningDetails.replace("$DOMAIN$", domain);
+  return Promise.resolve({
+    code: `if (!window.alreadyWarned) {
+             window.alreadyWarned = true;
+             console.warn("%c${ConsoleWarningEyeCatch}",
+               "font-size:50px; font-weight:bold; color:red; -webkit-text-stroke:1px black",
+               ${JSON.stringify("\n" + details)});
+           }`,
+  });
+}
+
+module.exports = promiseConsoleWarningScript;

--- a/src/lib/custom_functions.js
+++ b/src/lib/custom_functions.js
@@ -4,25 +4,34 @@
 
 "use strict";
 
-/* globals browser, module */
+/* globals browser, module, promiseConsoleWarningScript */
 
-const replaceStringInRequest = (
-  requestId,
-  inString,
-  outString,
-  inEncoding = "utf-8"
-) => {
+function getConsoleLogCallback(tabId) {
+  return () => {
+    // We don't actually know the site's we're hitting with these custom
+    // functions, so let's have the console say "this site".
+    promiseConsoleWarningScript("this site").then(script => {
+      browser.tabs.executeScript(tabId, script).catch(() => {});
+    });
+  };
+}
+
+const replaceStringInRequest = (requestId, inString, outString, callback) => {
   const filter = browser.webRequest.filterResponseData(requestId);
-  const decoder = new TextDecoder(inEncoding);
+  const decoder = new TextDecoder("utf-8");
   const encoder = new TextEncoder();
   const RE = new RegExp(inString, "g");
   const carryoverLength = inString.length;
   let carryover = "";
+  let doCallback = false;
 
   filter.ondata = event => {
     const replaced = (
       carryover + decoder.decode(event.data, { stream: true })
     ).replace(RE, outString);
+    if (callback && replaced.includes(outString)) {
+      doCallback = true;
+    }
     filter.write(encoder.encode(replaced.slice(0, -carryoverLength)));
     carryover = replaced.slice(-carryoverLength);
   };
@@ -32,17 +41,21 @@ const replaceStringInRequest = (
       filter.write(encoder.encode(carryover));
     }
     filter.close();
+    if (doCallback) {
+      callback();
+    }
   };
 };
 
 const CUSTOM_FUNCTIONS = {
   detectSwipeFix: injection => {
     const { urls, types } = injection.data;
-    const listener = (injection.data.listener = ({ requestId }) => {
+    const listener = (injection.data.listener = ({ requestId, tabId }) => {
       replaceStringInRequest(
         requestId,
         "preventDefault:true",
-        "preventDefault:false"
+        "preventDefault:false",
+        getConsoleLogCallback(tabId)
       );
       return {};
     });
@@ -55,6 +68,7 @@ const CUSTOM_FUNCTIONS = {
     browser.webRequest.onBeforeRequest.removeListener(listener);
     delete injection.data.listener;
   },
+
   noSniffFix: injection => {
     const { urls, contentType } = injection.data;
     const listener = (injection.data.listener = e => {
@@ -72,13 +86,15 @@ const CUSTOM_FUNCTIONS = {
     browser.webRequest.onHeadersReceived.removeListener(listener);
     delete injection.data.listener;
   },
+
   pdk5fix: injection => {
     const { urls, types } = injection.data;
-    const listener = (injection.data.listener = ({ requestId }) => {
+    const listener = (injection.data.listener = ({ requestId, tabId }) => {
       replaceStringInRequest(
         requestId,
         "VideoContextChromeAndroid",
-        "VideoContextAndroid"
+        "VideoContextAndroid",
+        getConsoleLogCallback(tabId)
       );
       return {};
     });

--- a/src/lib/ua_overrides.js
+++ b/src/lib/ua_overrides.js
@@ -4,7 +4,7 @@
 
 "use strict";
 
-/* globals browser, module */
+/* globals browser, module, promiseConsoleWarningScript */
 
 class UAOverrides {
   constructor(availableOverrides) {
@@ -76,6 +76,9 @@ class UAOverrides {
           }
         }
       }
+      promiseConsoleWarningScript(override.domain).then(script => {
+        browser.tabs.executeScript(details.tabId, script).catch(() => {});
+      });
       return { requestHeaders: details.requestHeaders };
     };
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -114,6 +114,7 @@
       "data/shims.js",
       "data/ua_overrides.js",
       "lib/about_compat_broker.js",
+      "lib/console_warning_helper.js",
       "lib/custom_functions.js",
       "lib/injections.js",
       "lib/picture_in_picture_overrides.js",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "name": "Web Compat",
+  "name": "@EXTENSION_NAME@",
   "description": "Urgent post-release fixes for web compatibility.",
   "version": "15.1.0",
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "@EXTENSION_NAME@",
   "description": "Urgent post-release fixes for web compatibility.",
-  "version": "15.1.0",
+  "version": "15.2.0",
 
   "applications": {
     "gecko": {

--- a/src/moz.build
+++ b/src/moz.build
@@ -62,6 +62,7 @@ FINAL_TARGET_FILES.features['webcompat@mozilla.org']['shims'] += [
 
 FINAL_TARGET_FILES.features['webcompat@mozilla.org']['lib'] += [
   'lib/about_compat_broker.js',
+  'lib/console_warning_helper.js',
   'lib/custom_functions.js',
   'lib/injections.js',
   'lib/intervention_helpers.js',


### PR DESCRIPTION
This PR collects a couple of "someone needs to do it"-patches I built in the last couple of weeks, but I wanted to collect them and land in between rotations, so I don't mess up someone's work. :) Reviewing by commit instead of looking at the whole patch is highly recommended.

There are seven commits in total, in the order they appear on GitHub:

1. Removes a bit of leftover from #178, where parts of the build tooling weren't removed with the Fennec documentation.
2. Creates a bit of documentation in the README on how to run the in-tree tests.
3. Adds validation rules for the URLs used in match patterns to avoid future breakage caused by invalid patterns.
4. That's a refactoring of Tom's old PR, #64. It's still doing the same, but I altered the message to be a bit more friendly. :)
5. That's just a small cleanup change that I did while doing other things.
6. This allows the extension name in the manifest to be changed per export location. For mozilla-central exports and .XPIs, the name will be set to "Web Compatibility Interventions", while for an export into android-components, the name will be "Mozilla Android Components - Web Compatibility Interventions" to match all the other WebExtensions shipped inside components.
7. Just a bump in version number, because the code changed.

r? @wisniewskit
r? @miketaylr (mainly to double-check the console message, and as a fyi that this will ship in v16. :))

---

And, just for the record, this is how the DevTools warning looks like:

<img width="622" alt="Screenshot 2020-09-15 at 01 15 44" src="https://user-images.githubusercontent.com/344777/93147268-0898bc00-f6f1-11ea-9b7f-8f74838ea108.png">
