### PR TITLE
Bug 1666771 - Create CSS intervention for zillow.com.

### DIFF
--- a/src/data/injections.js
+++ b/src/data/injections.js
@@ -413,6 +413,21 @@ const AVAILABLE_INJECTIONS = [
       ],
     },
   },
+  {
+    id: "bug1666771",
+    platform: "desktop",
+    domain: "zillow.com",
+    bug: "1666771",
+    contentScripts: {
+      allFrames: true,
+      matches: ["*://*.zillow.com/*"],
+      css: [
+        {
+          file: "injections/css/bug1666771-zilow-map-overdraw.css",
+        },
+      ],
+    },
+  },
 ];
 
 module.exports = AVAILABLE_INJECTIONS;

--- a/src/injections/css/bug1666771-zilow-map-overdraw.css
+++ b/src/injections/css/bug1666771-zilow-map-overdraw.css
@@ -1,0 +1,17 @@
+/**
+ * zillow.com - Zillow using massive amounts of memory.
+ * Bug #1666771 - https://bugzilla.mozilla.org/show_bug.cgi?id=1666771
+ * Bug #1662297 - https://bugzilla.mozilla.org/show_bug.cgi?id=1662297
+ *
+ * Zillow's map is using a lot of memory, caused by large amounts of overdraw
+ * inside the map while rendering object boundaries. Setting `overflow: hidden`
+ * is a workaround until Zillow addressed this in a more permanent way.
+ *
+ * Note that this override is not without side effects: some lines in the map
+ * may/will be cut off. There is no side-effect free solution to this, and
+ * not intervening means the browser just freezes.
+ */
+
+.zillow-map-layer svg.full-boundary-svg {
+  overflow: hidden !important;
+}


### PR DESCRIPTION
This addresses the performance issues caused by overdraw as reported in https://bugzilla.mozilla.org/show_bug.cgi?id=1662297.

r? @ksy36 