### PR TITLE
Bug 1712959 - use AppConstants.RELEASE_OR_BETA instead of AppConstants.BETA_OR_RELEASE.

### DIFF
--- a/src/experiment-apis/appConstants.js
+++ b/src/experiment-apis/appConstants.js
@@ -17,8 +17,8 @@ this.appConstants = class extends ExtensionAPI {
             return "dev_edition";
           } else if (AppConstants.EARLY_BETA_OR_EARLIER) {
             return "early_beta_or_earlier";
-          } else if (AppConstants.BETA_OR_RELEASE) {
-            return "beta_or_release";
+          } else if (AppConstants.RELEASE_OR_BETA) {
+            return "release_or_beta";
           }
           return "unknown";
         },

--- a/src/lib/shims.js
+++ b/src/lib/shims.js
@@ -19,17 +19,17 @@ const platformPromise = browser.runtime.getPlatformInfo().then(info => {
 });
 
 let debug = async function() {
-  if ((await releaseBranchPromise) !== "beta_or_release") {
+  if ((await releaseBranchPromise) !== "release_or_beta") {
     console.debug.apply(this, arguments);
   }
 };
 let error = async function() {
-  if ((await releaseBranchPromise) !== "beta_or_release") {
+  if ((await releaseBranchPromise) !== "release_or_beta") {
     console.error.apply(this, arguments);
   }
 };
 let warn = async function() {
-  if ((await releaseBranchPromise) !== "beta_or_release") {
+  if ((await releaseBranchPromise) !== "release_or_beta") {
     console.warn.apply(this, arguments);
   }
 };


### PR DESCRIPTION
Rob Wu discovered this one in https://bugzilla.mozilla.org/show_bug.cgi?id=1712959 - AppConstants.BETA_OR_RELEASE doesn't actually exist. 

r? @wisniewskit 