### PR TITLE
Use `node-lts-latest` Docker image in CI.

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -7,15 +7,17 @@ tasks:
     - $let:
           # XXX Set to `true` for private repos
           privateRepo: false
-          # XXX use "privileged", "system", or "mozillaonline-privileged" to
-          #     enable signing on push/PR. Note, this only works for public
-          #     repos for now. Release builds off shipit will get signing for
-          #     both public and private repos.
+          # XXX Use
+          # `system` for system add-on,
+          # `privileged` for AMO or self-hosted privileged add-on,
+          # `mozillaonline-privileged` for Mozilla China add-on,
+          # `normandy-privileged` for normandy add-on
+          # to enable siging on push/PR.
           xpiSigningType: "system"
           # The below doesn't need changing on initial repo setup
           taskgraph:
               branch: taskgraph
-              revision: 7dde9ce7740068d7b73218976343a28fc99be847
+              revision: 8051b20c975711d4ce09537285cef7451d043d8b
           template:
               repo: https://github.com/mozilla-extensions/xpi-template
               branch: master

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla/webcompat-addon",
   "version": "1.0.0",
+  "docker-image": "node-lts-latest",
   "private": true,
   "scripts": {
     "jake": "npx jake",

--- a/taskcluster/ci/build/kind.yml
+++ b/taskcluster/ci/build/kind.yml
@@ -19,6 +19,9 @@ job-defaults:
         docker-image:
             indexed: xpi.cache.level-3.docker-images.v2.node-14.latest
         chain-of-trust: true
+        volumes:
+            - /builds/worker/checkouts
+            - /builds/worker/.cache
     run:
         checkout:
             xpi: {}

--- a/taskcluster/ci/test/kind.yml
+++ b/taskcluster/ci/test/kind.yml
@@ -18,6 +18,9 @@ job-defaults:
         max-run-time: 7200
         docker-image:
             indexed: xpi.cache.level-3.docker-images.v2.node-14.latest
+        volumes:
+            - /builds/worker/checkouts
+            - /builds/worker/.cache
     run:
         checkout:
             xpi: {}

--- a/taskcluster/xpi_taskgraph/build.py
+++ b/taskcluster/xpi_taskgraph/build.py
@@ -32,13 +32,12 @@ def tasks_from_manifest(config, jobs):
             task["label"] = "build-{}".format(xpi_config["name"])
             env["XPI_NAME"] = xpi_config["name"]
             task.setdefault("extra", {})["xpi-name"] = xpi_config["name"]
-            if env.get("XPI_SSH_SECRET_NAME", ""):
-                checkout_config["ssh_secret_name"] = env["XPI_SSH_SECRET_NAME"]
+            if os.environ.get("XPI_SSH_SECRET_NAME"):
                 artifact_prefix = "xpi/build"
             else:
                 artifact_prefix = "public/build"
             task.setdefault("attributes", {})
-            task["attributes"]["artifact-prefix"] = artifact_prefix
+            task["attributes"]["artifact_prefix"] = artifact_prefix
             env["ARTIFACT_PREFIX"] = artifact_prefix
             artifacts = task["worker"].setdefault("artifacts", [])
             artifacts.append(
@@ -48,6 +47,7 @@ def tasks_from_manifest(config, jobs):
                     "path": "/builds/worker/artifacts",
                 }
             )
+            task["worker"]["docker-image"]["indexed"] = xpi_config["docker-image"]
             if xpi_config.get("install-type"):
                 env["XPI_INSTALL_TYPE"] = xpi_config["install-type"]
 

--- a/taskcluster/xpi_taskgraph/signing.py
+++ b/taskcluster/xpi_taskgraph/signing.py
@@ -11,7 +11,6 @@ from __future__ import absolute_import, print_function, unicode_literals
 import os
 
 from taskgraph.transforms.base import TransformSequence
-from taskgraph.util.taskcluster import get_artifact_prefix
 from taskgraph.util.schema import resolve_keyed_by
 from taskgraph.util.keyed_by import evaluate_keyed_by
 
@@ -19,9 +18,10 @@ from taskgraph.util.keyed_by import evaluate_keyed_by
 transforms = TransformSequence()
 
 FORMATS = {
+    "mozillaonline-privileged": "privileged_webextension",
+    "normandy-privileged": "privileged_webextension",
     "privileged": "privileged_webextension",
     "system": "system_addon",
-    "mozillaonline-privileged": "privileged_webextension",
 }
 
 
@@ -57,11 +57,11 @@ def build_signing_task(config, tasks):
             continue
         dep = task["primary-dependency"]
         task["dependencies"] = {"build": dep.label}
-        artifact_prefix = get_artifact_prefix(dep.task)
+        artifact_prefix = dep.task["payload"]["env"]["ARTIFACT_PREFIX"].rstrip('/')
         if not artifact_prefix.startswith("public"):
             scopes = task.setdefault('scopes', [])
             scopes.append(
-                "queue:get-artifact:{}/*".format(dep.task["payload"]["env"]["ARTIFACT_PREFIX"].rstrip('/'))
+                "queue:get-artifact:{}/*".format(artifact_prefix)
             )
         xpi_name = dep.task["extra"]["xpi-name"]
         # XXX until we can figure out what to sign, assume

--- a/taskcluster/xpi_taskgraph/test.py
+++ b/taskcluster/xpi_taskgraph/test.py
@@ -41,8 +41,9 @@ def test_tasks_from_manifest(config, jobs):
                     run["cwd"] = "{checkout}"
                 run["command"] = run["command"].format(target=target)
                 task["label"] = "t-{}-{}".format(target, xpi_name)
-                if env.get("XPI_SSH_SECRET_NAME", ""):
-                    checkout_config["ssh_secret_name"] = env["XPI_SSH_SECRET_NAME"]
+
+                task["worker"]["docker-image"]["indexed"] = xpi_config["docker-image"]
+                if os.environ.get("XPI_SSH_SECRET_NAME", ""):
                     artifact_prefix = "xpi/build"
                 else:
                     artifact_prefix = "public/build"

--- a/taskcluster/xpi_taskgraph/xpi_manifest.py
+++ b/taskcluster/xpi_taskgraph/xpi_manifest.py
@@ -65,6 +65,13 @@ def get_manifest():
                 subdir_list.remove(dir_)
                 continue
         if "package.json" in file_list:
+            # The presence of a "package.json" file in the repository
+            # does not necessarily mean there's an addon to sign. We
+            # need to give the ability to repository owners to turn off
+            # signing for non-addon "package.json" (e.g. libraries).
+            if "dontbuild" in file_list:
+                continue
+
             manifest = {"tests": []}
             if "yarn.lock" in file_list:
                 manifest["install-type"] = "yarn"
@@ -82,6 +89,14 @@ def get_manifest():
                 if target.startswith("test") or target == "lint":
                     manifest["tests"].append(target)
             manifest["name"] = package_json["name"].lower()
+            manifest[
+                "docker-image"
+            ] = "xpi.cache.level-3.docker-images.v2.node-14.latest"
+            if "docker-image" in package_json:
+                manifest["docker-image"] = (
+                    "xpi.cache.level-3.docker-images.v2.%s.latest"
+                    % package_json["docker-image"]
+                )
             manifest_list.append(ReadOnlyDict(manifest))
     check_manifest(manifest_list[:])
     return tuple(manifest_list)


### PR DESCRIPTION
(Hopefully) fixes #230.

Opening a PR to see if CI runs again.