### PR TITLE
No bug - Add bare-minimum specs for Shims.

### DIFF
--- a/spec/available_shims.spec.js
+++ b/spec/available_shims.spec.js
@@ -1,0 +1,56 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const WebExtManifestSchmea = require("./helpers/webext_manifest_schema");
+
+const AVAILABLE_SHIMS = require("../src/data/shims.js");
+
+describe("AVAILABLE_SHIMS", () => {
+  it("contains at least one Shim definition", () => {
+    expect(AVAILABLE_SHIMS.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("provide a unique ID for each shim", () => {
+    let ids = new Set();
+    let duplicates = new Set();
+
+    for (const shim of AVAILABLE_SHIMS) {
+      let id = shim.id;
+      if (ids.has(id)) {
+        console.error(`ID ${id} is not unique!`);
+        duplicates.add(id);
+      } else {
+        ids.add(id);
+      }
+    }
+
+    expect(duplicates.size).toBe(0);
+  });
+});
+
+for (const shim of AVAILABLE_SHIMS) {
+  describe(`shim #${shim.id}`, () => {
+    it("provides an ID", () => {
+      expect(shim.id).toBeTruthy();
+    });
+
+    it("provides a valid platform", () => {
+      expect(
+        ["all", "desktop", "android", "never matches"].includes(shim.platform)
+      ).toBeTruthy();
+    });
+
+    it("provides a bug ID", () => {
+      expect(shim.bug).toBeTruthy();
+    });
+
+    it("provides valid URLs", () => {
+      expect(
+        WebExtManifestSchmea.matchPatternsValid(shim.matches)
+      ).toBeTruthy();
+    });
+  });
+}

--- a/spec/helpers/webext_manifest_schema.js
+++ b/spec/helpers/webext_manifest_schema.js
@@ -9,10 +9,16 @@ const WEBEXT_MATCH_PATTERN = new RegExp(
   "i"
 );
 
-module.exports = {
-  matchPatternsValid: patterns => {
-    return patterns.every(
-      pattern => pattern.match(WEBEXT_MATCH_PATTERN) !== null
-    );
-  },
-};
+class WebextManifestSchema {
+  static matchPatternsValid(patterns) {
+    return patterns.every(pattern => {
+      if (typeof pattern == "string") {
+        return pattern.match(WEBEXT_MATCH_PATTERN) !== null;
+      } else {
+        return this.matchPatternsValid(pattern.patterns);
+      }
+    });
+  }
+}
+
+module.exports = WebextManifestSchema;


### PR DESCRIPTION
This is not meant to replace the in-product test or our work-in-progress test suite. but it provides a first stage of defense against common errors. The tests added here catch:

- Syntax errors in the definition file
- Missing or non-unique shim IDs
- Missing or invalid platform targets
- Missing bug IDs
- Missing or invalid URL match patterns

---

@wisniewskit and I briefly chatted about this before, but Tom didn't find the time so far, and I needed a bit of productivity right now. :)

r? @wisniewskit 