### PR TITLE
Bug 1749436 - Bump version number to 30.0.0

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "@EXTENSION_NAME@",
   "description": "Urgent post-release fixes for web compatibility.",
-  "version": "29.9.0",
+  "version": "30.0.0",
   "applications": {
     "gecko": {
       "id": "webcompat@mozilla.org",


### PR DESCRIPTION
Version bump to 30.0.0 after [1749436](https://bugzilla.mozilla.org/show_bug.cgi?id=1749436) landed.