### PR TITLE
Issue #256 - Add tooling to ensure and assist with the package.json version number

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -240,3 +240,23 @@ namespace("building", () => {
     );
   });
 });
+
+namespace("lint", () => {
+  desc("Checks that version numbers in package.json and manifest.json match");
+  task("verify-version-match", () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(SRC_DIR, "manifest.json")).toString()
+    );
+
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(".", "package.json")).toString()
+    );
+
+    if (manifest["version"] !== packageJson["version"]) {
+      console.error("Version number mismatch detected!");
+      console.error(`  manifest.json: ${manifest["version"]}`);
+      console.error(`  package.json:  ${packageJson["version"]}`);
+      fail("Version numbers in package.json and manifest.json do not match!");
+    }
+  });
+});

--- a/Jakefile
+++ b/Jakefile
@@ -259,4 +259,40 @@ namespace("lint", () => {
       fail("Version numbers in package.json and manifest.json do not match!");
     }
   });
+
+  desc("Overwrites version number in package.json with manifest data");
+  task("set-package-version", { async: true }, async () => {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(SRC_DIR, "manifest.json")).toString()
+    );
+
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(".", "package.json")).toString()
+    );
+
+    if (manifest["version"] !== packageJson["version"]) {
+      // This generates a JSON object with the current data, but the version
+      // property replaces with the manifest.json's value. It indents by two
+      // spaces, and then adds a final newline to match what prettier would
+      // give us.
+      // An alternative approach would to just write unformatted JSON, and then
+      // run prettier to make it match the codestyle. But for now, this appears
+      // to be working fine.
+      const newContents =
+        JSON.stringify(
+          Object.assign({}, packageJson, { version: manifest["version"] }),
+          null,
+          2
+        ) + "\n";
+
+      fs.writeFileSync(path.join(".", "package.json"), newContents);
+
+      // package-lock.json also contains the version number. Instead of trying
+      // to manually edit that file, let's run `npm install`, which will adjust
+      // the lockfile's version number as well.
+      // As all dependencies are hard-locked, this should not cause any
+      // unexpected version changes.
+      return jake.exec("npm install", complete);
+    }
+  });
 });

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Tests located in `src/tests/` are not automatically started by the CI in this re
 
 As `mozilla-central` is now mostly auto-formatted with prettier, and the config for that is really slim, this repo follows these guidelines. To automatically check and adjust the code style,
 
-1. Run `npm run prettier`
+1. Run `npm run autoformat`
 2. Done.
 
 ### Run tests and codestyle checks automatically before pushing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webcompat",
-  "version": "29.5.0",
+  "version": "30.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webcompat",
-      "version": "29.5.0",
+      "version": "30.2.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "jake": "10.8.2",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
   "docker-image": "node-lts-latest",
   "private": true,
   "scripts": {
-    "jake": "npx jake",
-    "prettier": "npx prettier --write '**/{*.css,*.js,*.jsm,*.json,Jakefile}'",
+    "autoformat:prettier": "npx prettier --write '**/{*.css,*.js,*.jsm,*.json,Jakefile}'",
+    "autoformat:version-number": "npx jake lint:set-package-version",
+    "autoformat": "./node_modules/.bin/npm-run-all 'autoformat:*'",
     "build": "npx jake export-xpi",
-    "lint:prettier": "npx prettier --check '**/{*.css,*.js,*.jsm,*.json,Jakefile}'",
+    "jake": "npx jake",
     "lint:package-version-match": "npx jake lint:verify-version-match",
+    "lint:prettier": "npx prettier --check '**/{*.css,*.js,*.jsm,*.json,Jakefile}'",
     "lint": "./node_modules/.bin/npm-run-all 'lint:*'",
     "test": "npx jasmine"
   },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prettier": "npx prettier --write '**/{*.css,*.js,*.jsm,*.json,Jakefile}'",
     "build": "npx jake export-xpi",
     "lint:prettier": "npx prettier --check '**/{*.css,*.js,*.jsm,*.json,Jakefile}'",
+    "lint:package-version-match": "npx jake lint:verify-version-match",
     "lint": "./node_modules/.bin/npm-run-all 'lint:*'",
     "test": "npx jasmine"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Urgent post-release fixes for web compatibility.",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla/webcompat-addon",
-  "version": "29.5.0",
+  "version": "30.2.0",
   "docker-image": "node-lts-latest",
   "private": true,
   "scripts": {


### PR DESCRIPTION
To us, the version number in `package.json` is pretty useless. We used to keep this manually in sync with the `manifest.json`s setting, but in https://github.com/mozilla-extensions/webcompat-addon/commit/7a445d242a8354c1b9347a60d415932091f753dc, I decided to stop that and just have it say `1.0.0` all the time, because to us, the relevant information is in `manifest.json` only.

Unfortunately, this causes an issue. CI uses the `package.json`s version number to set the version number in .xpi, and thus this is also relevant during rollouts. I discovered this during the recent Release-Hotfix, where the rollout systems wanted to deploy a version `1.0.0`. I talked to the Addons Pipeline team, and while they agreed that this is not perfect, reading the version from `manifest.json` isn't really an option either, since some System Addons contain multiple manifest files that get adjusted during build steps, and there generally are a lot of edge-cases.

So the best solution is for us to keep `manifest.json` and `package.json` always in sync. Since a mismatch can make a Release Hotfix more complicated, which usually isn't the time where you want to debug and manually adjust things due to the general pressure related to release hotfixes, this PR adds

- an extra step to the `lint` task that verifies that the version numbers match up, and if not, fails hard and thus will turn CI red.
- an extra step of the auto formatting pipeline in addition to running `prettier`, which automatically overwrites the version number in `package.json` with whatever is defined in `manifest.json`, so we don't have to manually do this.

---

Notice to @karlcow, @ksy36, and @wisniewskit: **This PR might break your workflow**:

- If you have set up the `pre-push` hook [as described in `README.md`](https://github.com/mozilla-extensions/webcompat-addon#run-tests-and-codestyle-checks-automatically-before-pushing), you will no longer be able to push if the version numbers do not match up. Instead, the push will fail, showing a `!! Running codestyle checks returned an error! Please run 'npm run lint' to see what's wrong.` error message. If you have not yet set up the `pre-push` hook, please do so: it's the simplest way to ensure that CI doesn't unexpectedly fail with linting errors, and it runs pretty fast.
- If you're currently using `npm run prettier` to have prettier auto-format all files, this task no longer exists, and you will see a `Missing script: "prettier"` error. Instead, please run `npm run autoformat` from now on, which will run `prettier`, but it will also auto-set the version number in `package.json`, so you don't have to do that manually. 

---

This closes #256 