### PR TITLE
No bug - Add the mozillaAddons permission.

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -64,6 +64,7 @@
   "content_security_policy": "script-src 'self' 'sha256-MmZkN2QaIHhfRWPZ8TVRjijTn5Ci1iEabtTEWrt9CCo='; default-src 'self'; base-uri moz-extension://*; object-src 'none'",
 
   "permissions": [
+    "mozillaAddons",
     "tabs",
     "webNavigation",
     "webRequest",


### PR DESCRIPTION
This adds a new permission, `mozillaAddons`. As per the email sent from TheOne three hours ago, this will be required for ShipIt starting around May 30.

I'm basing this PR on `release-hotfix` as there is a non-zero chance we have to ship an update before this change reaches the right tree. There is no need to land this in central, we can just merge this whenever the next update rolls around.

r? @ksy36, but please don't merge (I'll merge this into release-hotfix and main at the same time)