### PR TITLE
Fixes #249 - Update the default Chrome version for UA overrides in getDeviceAppropriateChromeUA

### DIFF
--- a/src/data/ua_overrides.js
+++ b/src/data/ua_overrides.js
@@ -838,7 +838,10 @@ const AVAILABLE_UA_OVERRIDES = [
     config: {
       matches: ["*://nordjyske.dk/*"],
       uaTransformer: originalUA => {
-        return UAHelpers.getDeviceAppropriateChromeUA("97.0.4692.9", "Pixel 4");
+        return UAHelpers.getDeviceAppropriateChromeUA(
+          "103.0.5060.71",
+          "Pixel 4"
+        );
       },
     },
   },
@@ -893,7 +896,7 @@ const AVAILABLE_UA_OVERRIDES = [
     config: {
       matches: ["*://www.otsuka.co.jp/fib/*"],
       uaTransformer: originalUA => {
-        return UAHelpers.getDeviceAppropriateChromeUA("97.0.4692.9");
+        return UAHelpers.getDeviceAppropriateChromeUA();
       },
     },
   },

--- a/src/lib/ua_helpers.js
+++ b/src/lib/ua_helpers.js
@@ -9,7 +9,7 @@
 var UAHelpers = {
   _deviceAppropriateChromeUAs: {},
   getDeviceAppropriateChromeUA(
-    chromeVersion = "76.0.3809.111",
+    chromeVersion = "103.0.5060.71",
     specificAndroidDevice = ""
   ) {
     const key = `${chromeVersion}:${specificAndroidDevice}`;


### PR DESCRIPTION
I've retested all overrides that are using `getDeviceAppropriateChromeUA` and all work as expected with newer version, here is the list:

site | device
-- | --
wp1-ext.usps.gov | - android
autotrader.ca | - android
lffl.org | - android
app.xiaomi.com | - android
www.dealnews.com | - android
apppmedia.jp | - android
covid.cdc.gov | - both
vmos.cn | - android
yebocasino.co.za | - android
automesseweb.jp | - android
slrclub.com | - android
workflow.base.vn | - android
nordjyske.dk | - android
www.dolcegabbana.com | - android
www.otsuka.co.jp | - desktop
animalplanet.com | - android
frontgate.com | - android

It would be nice to update version for interventions that don't use `getDeviceAppropriateChromeUA` function and have hardcoded UA strings. I've filed a separate issue for that https://github.com/mozilla-extensions/webcompat-addon/issues/286