### PR TITLE
Bug 1784199 - Font color reset for cookie popup and menu items

### DIFF
--- a/src/injections/css/bug1784199-entrata-platform-unsupported.css
+++ b/src/injections/css/bug1784199-entrata-platform-unsupported.css
@@ -4,6 +4,10 @@
  * WebCompat issue #100131 - https://webcompat.com/issues/100131
  */
 
+* {
+  color: unset;
+}
+
 #propertyProduct,
 .banner_overlay {
   display: none;


### PR DESCRIPTION
I've noticed the site also returns the following rule in the html template (together with the unsupported message html and the rest of css):

```css
* {
 color: #000000;
}
```
That affects menu items on one of the sites and cookie popup font color on all sites. So in this PR I unset the color.

Before and after below:

<img width="1722" alt="Screen Shot 2022-08-16 at 2 43 08 PM" src="https://user-images.githubusercontent.com/1303908/184955194-5adb51de-1690-4f62-9493-6f972f8c25be.png">

<img width="1720" alt="Screen Shot 2022-08-16 at 2 43 15 PM" src="https://user-images.githubusercontent.com/1303908/184955209-49f10251-c444-4735-bb8f-e4c486ea8497.png">

