### PR TITLE
Adjust export tooling for the new firefox-android monorepo.

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -87,16 +87,18 @@ function getMozillaCentralLocation() {
  * @returns {string} the location of AndroidComponents
  */
 function getAndroidComponentsLocation() {
-  let acLocation = path.resolve(
-    process.env.EXPORT_AC_LOCATION || "../android-components"
+  let monorepoLocation = path.resolve(
+    process.env.EXPORT_ANDROID_MONOREPO_LOCATION || "../firefox-android"
   );
+
+  let acLocation = path.join(monorepoLocation, "android-components");
 
   try {
     fs.statSync(acLocation).isDirectory();
     fs.statSync(`${acLocation}/gradlew`).isFile();
   } catch (ex) {
-    throw new Error(`android-components at ${acLocation} not found. Please set
-      the correct path into the EXPORT_AC_LOCATION environment variable!`);
+    throw new Error(`android monorepo at ${monorepoLocation} not found. Please set
+      the correct path into the EXPORT_ANDROID_MONOREPO_LOCATION environment variable!`);
   }
 
   return acLocation;
@@ -188,7 +190,7 @@ task("export-mc", ["build"], { async: true }, async () => {
   exportFiles(getMozillaCentralLocation(), "browser/extensions/webcompat");
 });
 
-desc("Exports the sources into the android-components repo");
+desc("Exports the sources into android-components");
 task("export-ac", ["build"], { async: true }, async () => {
   await setExtensionName(EXTENSION_NAME.androidComponents);
   deleteBuiltFiles(AC_IGNORE_PATHS);

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If this is the first time you're working with this repository, install the depen
 ### Exporting the sources into Android Components
 
 1. Ensure the version number is bumped in and `src/manifest.json`, appropriately (see [Versioning Scheme](https://github.com/mozilla/webcompat-addon/wiki/Versioning-Scheme) for more info).
-2. Make sure the `EXPORT_AC_LOCATION` environment variable is set to the root of your Android Components checkout.
+2. Make sure the `EXPORT_ANDROID_MONOREPO_LOCATION` environment variable is set to the root of your [firefox-android monorepo](https://github.com/mozilla-mobile/firefox-android) checkout.
 3. Run `npm run jake export-ac`.
 4. Find the exported files in your Android Components directory, ready to commit.
 


### PR DESCRIPTION
This adjusts the export tooling to be able to export into the new [firefox-android monorepo](https://github.com/mozilla-mobile/firefox-android), since the old android-components repo is now archived.

## 🚨 This will break your workflow, and maybe your heart if you don't pay attention!

While the jake export job is still called `export-ac`, I renamed the environment variable used to indicate the path of the repo. What used to be called `EXPORT_AC_LOCATION` is now called `EXPORT_ANDROID_MONOREPO_LOCATION`, and it should point to the **root directory** of your local `firefox-android` clone!

If you have set this variable in your `.zshrc` or `.bashrc` or whereever, **now** is a good chance to adjust that!

Explicitly pinging both @ksy36 and @wisniewskit for visibility. Note that the old workflow will no longer work, so you have to adjust your ENV vars before you touch the addon the next time!

r? whoever reviews first.