### PR TITLE
Bug 1794970 - Fix Android version RegEx.

### DIFF
--- a/src/lib/ua_helpers.js
+++ b/src/lib/ua_helpers.js
@@ -21,7 +21,7 @@ var UAHelpers = {
 
       if (userAgent.includes("Android")) {
         const RunningAndroidVersion =
-          userAgent.match(/Android\/[0-9.]+/) || "Android 6.0";
+          userAgent.match(/Android [0-9.]+/) || "Android 6.0";
         if (androidDevice) {
           UAHelpers._deviceAppropriateChromeUAs[
             key


### PR DESCRIPTION
The Android version in the UA string has the format `Android 42`, not `Android/42`. This most likely was a copy-paste bug.

r? @wisniewskit, please merge before your interventions to make sure this is included in 108.