### PR TITLE
Bug 1799369 - Use `browser_specific_settings` instead of `applications` in the manifest.

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,10 +3,10 @@
   "name": "@EXTENSION_NAME@",
   "description": "Urgent post-release fixes for web compatibility.",
   "version": "107.0.0",
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "webcompat@mozilla.org",
-      "strict_min_version": "59.0b5"
+      "strict_min_version": "102.0"
     }
   },
 


### PR DESCRIPTION
Also bump the min version to the current ESR 102. We don't really test the experiment APIs in older releases anyway.

This appears to be working fine, including installing an .xpi over an existing installation. I see no downside to this, so let's ship it.

r? @wisniewskit 