### PR TITLE
Bug 1841991 - Ship flexbox paint order intervention for wilton.com.

### DIFF
--- a/src/data/injections.js
+++ b/src/data/injections.js
@@ -1012,6 +1012,20 @@ const AVAILABLE_INJECTIONS = [
       ],
     },
   },
+  {
+    id: "bug1841991",
+    platform: "all",
+    domain: "wilton.com",
+    bug: "1841991",
+    contentScripts: {
+      matches: ["*://*.wilton.com/*"],
+      css: [
+        {
+          file: "injections/css/bug1841991-wilton.com-flexbox-painting-order.css",
+        },
+      ],
+    },
+  },
 ];
 
 module.exports = AVAILABLE_INJECTIONS;

--- a/src/injections/css/bug1841991-wilton.com-flexbox-painting-order.css
+++ b/src/injections/css/bug1841991-wilton.com-flexbox-painting-order.css
@@ -1,0 +1,23 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/**
+ * wilton.com - Images in the product carousel are not clickable
+ * web-bug #123994 - https://github.com/webcompat/web-bugs/issues/123994
+ *
+ * wilton.com relies on a non-interoperable CSS flexbox side-effect of
+ * specifying the `order` on elements. See bug 1841986. This intervention
+ * unsets the order, as it's not doing anything useful in the Desktop view
+ * anyway.
+ */
+
+@media (min-width: 801px) {
+  .product-page
+    .body
+    > div
+    > .container.product-details-page
+    .productView-image {
+    order: unset;
+  }
+}


### PR DESCRIPTION
I'm feeling adventurous today, so I decided to build the intervention right after diagnosis. I'm not sure if this is a good idea because it reduces context switches (and the need for cross-people information transfer), or if this is a bad idea because it fragments review time and may create merge conflicts.

Either way, r? @wisniewskit (it's your cycle).