### PR TITLE
Porting webcompat interventions injections from contentScripts to scripting API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webcompat",
-  "version": "118.1.0",
+  "version": "118.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webcompat",
-      "version": "118.1.0",
+      "version": "118.2.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "jake": "10.8.7",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Urgent post-release fixes for web compatibility.",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla/webcompat-addon",
-  "version": "118.1.0",
+  "version": "118.2.0",
   "docker-image": "node-lts-latest",
   "private": true,
   "scripts": {

--- a/spec/helpers/mock_webextension_apis.js
+++ b/spec/helpers/mock_webextension_apis.js
@@ -19,8 +19,12 @@ jasmine.getGlobal().browser = {
       addListener: () => {},
     },
   },
-  contentScripts: {
-    register: () => {},
+  scripting: {
+    registerContentScripts: async () => {},
+    unregisterContentScripts: async () => {},
+    getRegisteredContentScripts: async () => {
+      return [];
+    },
   },
   runtime: {
     getPlatformInfo: async () => {

--- a/src/data/shims.js
+++ b/src/data/shims.js
@@ -589,7 +589,6 @@ const AVAILABLE_SHIMS = [
     ],
     contentScripts: [
       {
-        cookieStoreId: "firefox-private",
         js: "firebase.js",
         runAt: "document_start",
         matches: [

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "@EXTENSION_NAME@",
   "description": "Urgent post-release fixes for web compatibility.",
-  "version": "118.1.0",
+  "version": "118.2.0",
   "browser_specific_settings": {
     "gecko": {
       "id": "webcompat@mozilla.org",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -65,6 +65,7 @@
 
   "permissions": [
     "mozillaAddons",
+    "scripting",
     "tabs",
     "webNavigation",
     "webRequest",


### PR DESCRIPTION
This PR include a draft of the changes needed to port the webcompat interventions builtin addon from the contentScripts.register API method to the scripting.registerContentScripts API method.

The motivation behind it is that the content scripts dynamically registered using contentScripts.register are expected to be unregistered automatically if the background page is destroyed, while the ones registered through the scripting.registerContentScripts API are expected to stay registered even after the background page is destroyed.


While this PR does not aim to convert the persistent background page into an event page, it may still be interesting to consider it on its own, because it would still help to make the webcompat interventions to be more resilient to extension process shutdown/crashes, because the interventions content scripts will be stay registered even after the background page is gone due to an extension process shutdown/crash.

TODO Task list:
- [x] determine what to do with Shim cookieStoreId property (not yet supported by the scripting API, tracked by [Bug 1764572](https://bugzilla.mozilla.org/1764572))
- [x] rebase on top of a more recent github repo tip
- [x] apply additional changes based on the last round of review comments (change _availableInjections into just a Set of script ids, port Shim to the scripting API, remove cookieStoreId from the firebase shim)
- [x] apply changes needed because enableContentScripts should account that enableInjection can be called for single injection from AboutCompatBroker (and it wouldn't get an array of registered content scripts)
- [x] apply changes needed to make sure Shims also accounts for already scripting API's registered content script when the webcompat background page is loaded after a crash, like we are doing for Injections
- [x] manually test out again the new version in a local nightly build
- [ ] determine STR for a Scenario 3: test enabling/disabling specific shims and injection from AboutCompatBroker after the webcompat background page has been reloaded automatically after a crash
- [ ] manually test out again if there are any further changes

---

### Manual Testing STR

- export the EXPORT_MC_LOCATION env var pointing to a mozilla-central clone and run `npm run jake export-mc` as described in this repo README.md doc file
- build and run Firefox from that mozilla-central clone

#### Scenario 1: webcompat background page reloaded automatically after an extension process crash

- Open a tab to about:processes and expect the Extension process to be listed, and take note of its process ID
- Open the browser console, enable Multiprocess mode and confirm that the logs from webcompat (the ones originated from the shims.js by default) 
- Navigate a tab to about:crashextensions
- Switch back to about:processes and expect the Extension process to still be listed but its process ID to be a new one
- Confirm in the browser console that the logs of a successfull webcompat background page load have been logged (e.g. the logs emitted from shims.js) and no unexpected error (e.g. registering an already registered content script) has been logged
- Navigate a tab to a page where an injection or a shim are expected to be active, e.g. http://webcompat-addon-testbed.herokuapp.com/ and confirm that the expected injection or shim are active (or check if their content script are listed in the Debugger panel as expected) 

#### Scenario 2: webcompat background page not running anymore due to extension process crashes exceeded threshold

- open a tab on about:config and set `extensions.background.disableRestartPersistentAfterCrash` to `true` to disable the autorestart of the persistent background pages after a crash (to simulate the condition of extension process crashes exceeding the threshold and the process not being restarted anymore)  
- Open a tab to about:processes and expect the Extension process to be listed
- open a new tab and navigate it to about:crashextensions
- switch back to about:processes and expect the Extension process to not be listed anymore
- Navigate a tab to a page where an injection or a shim are expected to be active, e.g. http://webcompat-addon-testbed.herokuapp.com/ and confirm that the expected injection or shim are active (or check if their content script are listed in the Debugger panel as expected)