### PR TITLE
apply ua override for gbf.game.mbga.jp

### DIFF
--- a/src/data/ua_overrides.js
+++ b/src/data/ua_overrides.js
@@ -486,7 +486,7 @@ const AVAILABLE_UA_OVERRIDES = [
     domain: "granbluefantasy.jp",
     bug: "1722954",
     config: {
-      matches: ["*://*.granbluefantasy.jp/*"],
+      matches: ["*://*.granbluefantasy.jp/*", "*://*.gbf.game.mbga.jp/*"],
       uaTransformer: originalUA => {
         return originalUA + " iPhone OS 12_0 like Mac OS X";
       },


### PR DESCRIPTION
it is another domain of gbf. mabe this compat workaround also works for it. but i haven't tested yet. because i have only a phone at this moment

see also: https://github.com/webcompat/web-bugs/issues/34310#issuecomment-1708967412