### PR TITLE
Fixes #275: Convert AboutCompat.jsm to an ES module.

### DIFF
--- a/src/about-compat/AboutCompat.sys.mjs
+++ b/src/about-compat/AboutCompat.sys.mjs
@@ -2,21 +2,14 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-"use strict";
-
-var EXPORTED_SYMBOLS = ["AboutCompat"];
-
-const Services =
-  globalThis.Services ||
-  ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
-
 const addonID = "webcompat@mozilla.org";
 const addonPageRelativeURL = "/about-compat/aboutCompat.html";
 
-function AboutCompat() {
+export function AboutCompat() {
   this.chromeURL =
     WebExtensionPolicy.getByID(addonID).getURL(addonPageRelativeURL);
 }
+
 AboutCompat.prototype = {
   QueryInterface: ChromeUtils.generateQI(["nsIAboutModule"]),
   getURIFlags() {

--- a/src/about-compat/aboutPage.js
+++ b/src/about-compat/aboutPage.js
@@ -4,11 +4,7 @@
 
 "use strict";
 
-/* global ExtensionAPI, XPCOMUtils */
-
-const Services =
-  globalThis.Services ||
-  ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
+/* global ExtensionAPI, XPCOMUtils, Services */
 
 XPCOMUtils.defineLazyServiceGetter(
   this,

--- a/src/about-compat/aboutPageProcessScript.js
+++ b/src/about-compat/aboutPageProcessScript.js
@@ -19,8 +19,8 @@ if (!Cm.isCIDRegistered(classID)) {
   );
 
   const factory = ComponentUtils.generateSingletonFactory(function () {
-    const { AboutCompat } = ChromeUtils.import(
-      "resource://webcompat/AboutCompat.jsm"
+    const { AboutCompat } = ChromeUtils.importESModule(
+      "resource://webcompat/AboutCompat.sys.mjs"
     );
     return new AboutCompat();
   });

--- a/src/components.conf
+++ b/src/components.conf
@@ -11,7 +11,7 @@ Classes = [
     {
         'cid': '{97bf9550-2a7b-11e9-b56e-0800200c9a66}',
         'contract_ids': ['@mozilla.org/network/protocol/about;1?what=compat'],
-        'jsm': 'resource://webcompat/AboutCompat.jsm',
+        'esModule': 'resource://webcompat/AboutCompat.sys.mjs',
         'constructor': 'AboutCompat',
     },
 ]

--- a/src/moz.build
+++ b/src/moz.build
@@ -16,7 +16,7 @@ FINAL_TARGET_FILES.features["webcompat@mozilla.org"]["about-compat"] += [
     "about-compat/aboutCompat.css",
     "about-compat/aboutCompat.html",
     "about-compat/aboutCompat.js",
-    "about-compat/AboutCompat.jsm",
+    "about-compat/AboutCompat.sys.mjs",
     "about-compat/aboutPage.js",
     "about-compat/aboutPage.json",
     "about-compat/aboutPageProcessScript.js",


### PR DESCRIPTION
This converts AboutCompat.jsm to an ES module and changes the necessary support infrastructure.

I have not tested it on android, so I'm not certain it will work there. Performing the export on desktop and running the tests seems to work fine.