### PR TITLE
No bug - Adjust export tooling for the in-tree Android Components.

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -83,28 +83,6 @@ function getMozillaCentralLocation() {
 }
 
 /**
- * @throws if Android-Components could not be found
- * @returns {string} the location of AndroidComponents
- */
-function getAndroidComponentsLocation() {
-  let monorepoLocation = path.resolve(
-    process.env.EXPORT_ANDROID_MONOREPO_LOCATION || "../firefox-android"
-  );
-
-  let acLocation = path.join(monorepoLocation, "android-components");
-
-  try {
-    fs.statSync(acLocation).isDirectory();
-    fs.statSync(`${acLocation}/gradlew`).isFile();
-  } catch (ex) {
-    throw new Error(`android monorepo at ${monorepoLocation} not found. Please set
-      the correct path into the EXPORT_ANDROID_MONOREPO_LOCATION environment variable!`);
-  }
-
-  return acLocation;
-}
-
-/**
  * Replaces file list placeholders in moz.build and manifest.json
  *
  * returns {promise}
@@ -184,6 +162,9 @@ task(
   () => {}
 );
 
+desc("Exports the sources into both mozilla-central and android-components");
+task("export", ["export-mc", "export-ac"]);
+
 desc("Exports the sources into mozilla-central");
 task("export-mc", ["build"], { async: true }, async () => {
   await setExtensionName(EXTENSION_NAME.default);
@@ -195,8 +176,8 @@ task("export-ac", ["build"], { async: true }, async () => {
   await setExtensionName(EXTENSION_NAME.androidComponents);
   deleteBuiltFiles(AC_IGNORE_PATHS);
   exportFiles(
-    getAndroidComponentsLocation(),
-    "components/feature/webcompat/src/main/assets/extensions/webcompat"
+    getMozillaCentralLocation(),
+    "mobile/android/android-components/components/feature/webcompat/src/main/assets/extensions/webcompat"
   );
 });
 

--- a/README.md
+++ b/README.md
@@ -14,19 +14,15 @@ Running the extension without a built and set up `mozilla-central` is not possib
 
 If this is the first time you're working with this repository, install the dependencies with `npm install`.
 
-### Exporting the sources to `mozilla-central`
+### Exporting the built source code for committing
 
 1. Ensure the version number is bumped in `src/manifest.json`, appropriately (see [Versioning Scheme](https://github.com/mozilla/webcompat-addon/wiki/Versioning-Scheme) for more info).
 2. Make sure the `EXPORT_MC_LOCATION` environment variable is set to the root of your `mozilla-central` checkout.
-3. Run `npm run jake export-mc`.
-4. Find the exported files in your `mozilla-central` directory, ready to commit.
-
-### Exporting the sources into Android Components
-
-1. Ensure the version number is bumped in and `src/manifest.json`, appropriately (see [Versioning Scheme](https://github.com/mozilla/webcompat-addon/wiki/Versioning-Scheme) for more info).
-2. Make sure the `EXPORT_ANDROID_MONOREPO_LOCATION` environment variable is set to the root of your [firefox-android monorepo](https://github.com/mozilla-mobile/firefox-android) checkout.
-3. Run `npm run jake export-ac`.
-4. Find the exported files in your Android Components directory, ready to commit.
+3. Depending on where you want to export to, run one of the following:
+   - For exporting into `mozilla-central` into both the Desktop build and the Android Components, run `npm run jake export`.
+   - For exporting into the Desktop tree of `mozilla-central`, run `npm run jake export-mc`.
+   - For exporting into the Android Components tree of `mozilla-central`, run `npm run jake export-ac`.
+4. Your changes will now be in your `mozilla-central` checkout. Double-check the results, and you're ready to commit.
 
 ### Run the changed extension sources
 
@@ -41,7 +37,7 @@ If you want to debug this extension on recent Desktop versions, you can use `abo
 5. Select `./src/manifest.json` and hit open.
 6. Test!
 
-### Testing on the new Firefox for Android (Fenix)
+### Testing in Firefox for Android (Fenix)
 
 Since the WebCompat feature inside Fenix is not shipped directly to the product but is included via a universal android component, you need both a local copy of Fenix and a local copy of Android-Components on your system. To build, make sure to follow the [Mozilla Android Components' instructions on how to test unreleased component code](https://mozac.org/contributing/testing-components-inside-app), and use the android-component exporter (see above) to get your sources into the repo.
 


### PR DESCRIPTION
This also adds a new command, `npm run jake export`, that will export both mobile and desktop. Since those two are in the same repository anyway, I don't see a good reason to separate them in most use-cases. The individual commands still exist, though, in case you only need to update one.

r? @ksy36 
fyi! @wisniewskit 