### PR TITLE
Issue #333 - Ensure all interventions have a globally unique ID.

### DIFF
--- a/spec/all_interventions.spec.js
+++ b/spec/all_interventions.spec.js
@@ -1,0 +1,32 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+const AVAILABLE_INJECTIONS = require("../src/data/injections.js");
+const AVAILABLE_SHIMS = require("../src/data/shims.js");
+const AVAILABLE_UA_OVERRIDES = require("../src/data/ua_overrides.js");
+
+describe("all interventions", () => {
+  it("provide a unique ID for all interventions", () => {
+    let ids = new Set();
+    let duplicates = new Set();
+
+    for (const injection of [].concat(
+      AVAILABLE_INJECTIONS,
+      AVAILABLE_SHIMS,
+      AVAILABLE_UA_OVERRIDES
+    )) {
+      let id = injection.id;
+      if (ids.has(id)) {
+        console.error(`Intervention ID ${id} is not unique!`);
+        duplicates.add(id);
+      } else {
+        ids.add(id);
+      }
+    }
+
+    expect(duplicates.size).toBe(0);
+  });
+});

--- a/spec/available_injections.spec.js
+++ b/spec/available_injections.spec.js
@@ -15,23 +15,6 @@ describe("AVAILABLE_INJECTIONS", () => {
   it("contains at least one injection definition", () => {
     expect(AVAILABLE_INJECTIONS.length).toBeGreaterThanOrEqual(1);
   });
-
-  it("provide a unique ID for each injection", () => {
-    let ids = new Set();
-    let duplicates = new Set();
-
-    for (const injection of AVAILABLE_INJECTIONS) {
-      let id = injection.id;
-      if (ids.has(id)) {
-        console.error(`ID ${id} is not unique!`);
-        duplicates.add(id);
-      } else {
-        ids.add(id);
-      }
-    }
-
-    expect(duplicates.size).toBe(0);
-  });
 });
 
 for (const injection of AVAILABLE_INJECTIONS) {

--- a/spec/available_shims.spec.js
+++ b/spec/available_shims.spec.js
@@ -12,23 +12,6 @@ describe("AVAILABLE_SHIMS", () => {
   it("contains at least one Shim definition", () => {
     expect(AVAILABLE_SHIMS.length).toBeGreaterThanOrEqual(1);
   });
-
-  it("provide a unique ID for each shim", () => {
-    let ids = new Set();
-    let duplicates = new Set();
-
-    for (const shim of AVAILABLE_SHIMS) {
-      let id = shim.id;
-      if (ids.has(id)) {
-        console.error(`ID ${id} is not unique!`);
-        duplicates.add(id);
-      } else {
-        ids.add(id);
-      }
-    }
-
-    expect(duplicates.size).toBe(0);
-  });
 });
 
 for (const shim of AVAILABLE_SHIMS) {

--- a/spec/available_ua_overrides.spec.js
+++ b/spec/available_ua_overrides.spec.js
@@ -14,23 +14,6 @@ describe("AVAILABLE_UA_OVERRIDES", () => {
   it("contains at least one UA override definition", () => {
     expect(AVAILABLE_UA_OVERRIDES.length).toBeGreaterThanOrEqual(1);
   });
-
-  it("provide a unique ID for each override", () => {
-    let ids = new Set();
-    let duplicates = new Set();
-
-    for (const override of AVAILABLE_UA_OVERRIDES) {
-      let id = override.id;
-      if (ids.has(id)) {
-        console.error(`ID ${id} is not unique!`);
-        duplicates.add(id);
-      } else {
-        ids.add(id);
-      }
-    }
-
-    expect(duplicates.size).toBe(0);
-  });
 });
 
 for (const override of AVAILABLE_UA_OVERRIDES) {

--- a/src/data/injections.js
+++ b/src/data/injections.js
@@ -639,7 +639,7 @@ const AVAILABLE_INJECTIONS = [
     },
   },
   {
-    id: "bug1827678-webc77727",
+    id: "bug1827678-webc77727-js",
     platform: "android",
     domain: "free4talk.com",
     bug: "1827678",

--- a/src/data/ua_overrides.js
+++ b/src/data/ua_overrides.js
@@ -800,7 +800,7 @@ const AVAILABLE_UA_OVERRIDES = [
      * Bug 1827678 - UA override for www.free4talk.com
      * Webcompat issue #77727 - https://webcompat.com/issues/77727
      */
-    id: "bug1827678-webc77727",
+    id: "bug1827678-webc77727-ua",
     platform: "android",
     domain: "www.free4talk.com",
     bug: "1827678",


### PR DESCRIPTION
Previously, the tests only verified that the ID is unique within each "kind" of intervention (i.e. UA override, Injection, Shim). This isn't reliable in practice.

The "disable" button on `about:compat` sends a message with `{ command: "toggle", id }` to the broker, and it doesn't distinguish between the different kinds of interventions. So the ID has to be globally unique, not just within each set.

This fixes the one instance where this happened, and also moves the test for this into a global test.

Fixes #333.

r? @wisniewskit 