### PR TITLE
Bug 1776229 - Add x.com to the Twitter DraftJS intervention.

### DIFF
--- a/src/data/injections.js
+++ b/src/data/injections.js
@@ -290,6 +290,8 @@ const AVAILABLE_INJECTIONS = [
         "*://www.facebook.com/*", // Bug 1739489
         "*://twitter.com/*", // Bug 1776229
         "*://mobile.twitter.com/*", // Bug 1776229
+        "*://x.com/*", // Bug 1776229
+        "*://mobile.x.com/*", // Bug 1776229
         "*://*.reddit.com/*", // Bug 1829755
       ],
       js: [


### PR DESCRIPTION
This adds `x.com` to the Twitter DraftJS intervention. I decided not to remove the old domains, just in case they decide to switch back again...

r? @ksy36 