### PR TITLE
Bug 1904556 - fix the CSS intervention to disable pull-to-refresh on the YouTube Shorts mobile page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webcompat",
-  "version": "129.1.0",
+  "version": "129.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webcompat",
-      "version": "129.1.0",
+      "version": "129.2.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "jake": "10.9.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Urgent post-release fixes for web compatibility.",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla/webcompat-addon",
-  "version": "129.1.0",
+  "version": "129.2.0",
   "docker-image": "node-lts-latest",
   "private": true,
   "scripts": {

--- a/src/data/injections.js
+++ b/src/data/injections.js
@@ -1066,7 +1066,7 @@ const AVAILABLE_INJECTIONS = [
     domain: "YouTube Shorts",
     bug: "1882040",
     contentScripts: {
-      matches: ["*://m.youtube.com/shorts/*"],
+      matches: ["*://m.youtube.com/shorts", "*://m.youtube.com/shorts/*"],
       css: [
         {
           file: "injections/css/bug1882040-disable-pull-to-refresh.css",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "@EXTENSION_NAME@",
   "description": "Urgent post-release fixes for web compatibility.",
-  "version": "129.1.0",
+  "version": "129.2.0",
   "browser_specific_settings": {
     "gecko": {
       "id": "webcompat@mozilla.org",


### PR DESCRIPTION
We also need to match the base YouTube Shorts domain, otherwise pull-to-refresh will still work once on the tab if the user directly visits m.youtube.com/shorts