### PR TITLE
Bug 1815733 - Override navigator.clipboard.read() with a no-op for Outlook.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "webcompat",
-  "version": "129.11.0",
+  "version": "130.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "webcompat",
-      "version": "129.11.0",
+      "version": "130.0.0",
       "license": "MPL-2.0",
       "devDependencies": {
         "jake": "10.9.2",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Urgent post-release fixes for web compatibility.",
   "license": "MPL-2.0",
   "repository": "https://github.com/mozilla/webcompat-addon",
-  "version": "129.11.0",
+  "version": "130.0.0",
   "docker-image": "node-lts-latest",
   "private": true,
   "scripts": {

--- a/src/data/injections.js
+++ b/src/data/injections.js
@@ -1139,6 +1139,28 @@ const AVAILABLE_INJECTIONS = [
       ],
     },
   },
+  {
+    id: "bug1815733",
+    platform: "desktop",
+    domain: "Office 365 Outlook locations",
+    bug: "1815733",
+    contentScripts: {
+      matches: [
+        "*://outlook.live.com/*",
+        "*://outlook.office.com/*",
+        "*://outlook.office365.com/*",
+        "*://outlook.office365.us/*",
+        "*://*.outlook.cn/*",
+        "*://*.outlook.com/*",
+      ],
+      js: [
+        {
+          file: "injections/js/bug1815733-outlook365-clipboard-read-noop.js",
+        },
+      ],
+      allFrames: true,
+    },
+  },
 ];
 
 module.exports = AVAILABLE_INJECTIONS;

--- a/src/injections/js/bug1815733-outlook365-clipboard-read-noop.js
+++ b/src/injections/js/bug1815733-outlook365-clipboard-read-noop.js
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+"use strict";
+
+/**
+ * Bug 1815733 - Annoying "Paste" overlay when trying to paste
+ *
+ * As per https://bugzilla.mozilla.org/show_bug.cgi?id=1815733#c13, Outlook
+ * is calling clipboard.read() again when they shouldn't. This is causing a
+ * visible "Paste" prompt for the user, which is stealing focus and can be
+ * annoying.
+ */
+
+/* globals exportFunction */
+
+Object.defineProperty(navigator.clipboard.wrappedJSObject, "read", {
+  value: exportFunction(function () {
+    return new Promise((resolve, _) => {
+      console.log(
+        "clipboard.read() has been overwriten with a no-op. See https://bugzilla.mozilla.org/show_bug.cgi?id=1815733#c13 for details."
+      );
+
+      resolve();
+    });
+  }, navigator.clipboard),
+});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 2,
   "name": "@EXTENSION_NAME@",
   "description": "Urgent post-release fixes for web compatibility.",
-  "version": "129.11.0",
+  "version": "130.0.0",
   "browser_specific_settings": {
     "gecko": {
       "id": "webcompat@mozilla.org",


### PR DESCRIPTION
r? @wisniewskit 

See https://bugzilla.mozilla.org/show_bug.cgi?id=1815733#c13 for why. this seems to work, and pasting still works, but without the annoying native popover.