### PR TITLE
Bug 1932687 - Add onPrivateSessionEnd shim for tests.

### DIFF
--- a/spec/helpers/mock_webextension_apis.js
+++ b/spec/helpers/mock_webextension_apis.js
@@ -52,6 +52,9 @@ jasmine.getGlobal().browser = {
     onSmartBlockEmbedUnblock: {
       addListener: () => {},
     },
+    onPrivateSessionEnd: {
+      addListener: () => {},
+    },
     revoke: async () => {},
     shim: async () => {},
     wasRequestUnblocked: async () => false,


### PR DESCRIPTION
This was added in bug 1932687, but it [broke the tests](https://github.com/mozilla-extensions/webcompat-addon/runs/36320979575). This fixes it.